### PR TITLE
Do not remove entry node of sketch when the resulting DFA has the entry node as non-accept

### DIFF
--- a/src/solver/type_lattice.rs
+++ b/src/solver/type_lattice.rs
@@ -13,8 +13,6 @@ use std::{
     rc::Rc,
 };
 
-
-
 /// A named lattice elment can be cloned and also has a string name.
 pub trait NamedLatticeElement: Lattice + Clone {
     /// The name of this lattice element.
@@ -254,7 +252,8 @@ impl LatticeDefinition {
 
         let nds: HashMap<String, CustomLatticeElement> = self
             .less_than_relations_between_handles
-            .iter().flat_map(|x| vec![&x.0, &x.1].into_iter())
+            .iter()
+            .flat_map(|x| vec![&x.0, &x.1].into_iter())
             .map(|elem| {
                 (
                     elem.clone(),

--- a/src/solver/type_sketch.rs
+++ b/src/solver/type_sketch.rs
@@ -1948,10 +1948,13 @@ impl<U: std::cmp::PartialEq + Clone + Lattice + AbstractMagma<Additive> + Displa
             .into_iter()
             .filter(|idx| !accepts.contains(idx))
         {
-            let nd_idx = mp
-                .get(&reject_idx)
-                .expect("all indicies should be contained in the mapping");
-            grph.remove_node(*nd_idx);
+            // it's ok to not remove a reject entry because if an entry is reject then nothing can reach it, and it can reach nothing
+            if reject_idx != dfa.entry() {
+                let nd_idx = mp
+                    .get(&reject_idx)
+                    .expect("all indicies should be contained in the mapping");
+                grph.remove_node(*nd_idx);
+            }
         }
 
         (
@@ -2041,6 +2044,7 @@ impl<U: std::cmp::PartialEq + Clone + Lattice + AbstractMagma<Additive> + Displa
             self.find_representative_nodes_for_new_nodes(entry, &grph, other);
 
         let mut weight_mapping = MappingGraph::from_dfa_and_labeling(grph);
+
         for (base_node, (o1, o2)) in mapping_from_new_node_to_representatives_in_orig.iter() {
             let self_label = o1
                 .and_then(|o1| self.quotient_graph.get_graph().node_weight(o1).cloned())
@@ -2054,6 +2058,7 @@ impl<U: std::cmp::PartialEq + Clone + Lattice + AbstractMagma<Additive> + Displa
             //assert!(!self_dtvs.is_empty() && !other_dtvs.is_empty());
 
             let new_label = lattice_op(&self_label, &other_label);
+            assert!(weight_mapping.get_graph().contains_node(*base_node));
             *weight_mapping
                 .get_graph_mut()
                 .node_weight_mut(*base_node)


### PR DESCRIPTION
Since non-accept nodes can never have edges to accept nodes and the entry cannot have any incoming nodes, we know the node is not connected to anything but itself so it is safe to keep the entry node. Keeping the entry node is required since the sketches entry node must always be available