### PR TITLE
Speed up file loads

### DIFF
--- a/src/inference_job/mod.rs
+++ b/src/inference_job/mod.rs
@@ -206,8 +206,9 @@ impl InferenceJob {
         lattice_json: &str,
     ) -> anyhow::Result<LatticeDefinition> {
         let lattice_fl = std::fs::File::open(lattice_json)?;
-        let lattice_def: LatticeDefinition = serde_json::from_reader(lattice_fl)
-            .map_err(|e| anyhow::Error::from(e).context("lattice json"))?;
+        let lattice_def: LatticeDefinition =
+            serde_json::from_reader(std::io::BufReader::new(lattice_fl))
+                .map_err(|e| anyhow::Error::from(e).context("lattice json"))?;
         Ok(lattice_def)
     }
 

--- a/src/inference_job/mod.rs
+++ b/src/inference_job/mod.rs
@@ -338,7 +338,7 @@ impl InferenceJob {
         let reaching_defs_start_of_block = reg_context
             .iter()
             .filter_map(|(k, v)| {
-                let nd = grph[(*k)];
+                let nd = grph[*k];
                 match nd {
                     Node::BlkStart(blk, _sub) => Some((blk.tid.clone(), v.clone())),
                     _ => None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,14 +103,15 @@ mod tests {
     fn parse_scc_constraints(fname: &str) -> anyhow::Result<Vec<DeserSCCCons>> {
         let f = std::fs::File::open(fname)?;
 
-        let mut v: Vec<DeserSCCCons> = serde_json::from_reader(f)?;
+        let mut v: Vec<DeserSCCCons> = serde_json::from_reader(std::io::BufReader::new(f))?;
         normalize_cons(&mut v);
         Ok(v)
     }
 
     fn parse_ctype_mapping(fname: &str) -> anyhow::Result<HashMap<NodeIndex, CType>> {
         let f = std::fs::File::open(fname)?;
-        let content: HashMap<NodeIndex, CType> = serde_json::from_reader(f)?;
+        let content: HashMap<NodeIndex, CType> =
+            serde_json::from_reader(std::io::BufReader::new(f))?;
         Ok(content)
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -31,7 +31,8 @@ pub fn get_intermediate_representation_for_reader(
     rdr: impl Read,
     binary: &[u8],
 ) -> Result<Project> {
-    let mut pcode_proj: cwe_checker_lib::pcode::Project = serde_json::from_reader(rdr)?;
+    let mut pcode_proj: cwe_checker_lib::pcode::Project =
+        serde_json::from_reader(std::io::BufReader::new(rdr))?;
     let base_addr = cwe_checker_lib::utils::get_binary_base_address(binary)?;
     let msgs = pcode_proj.normalize();
 


### PR DESCRIPTION
`binary_to_types` is slower than it should be, simply because it spends a large amount of its time performing a _huge_ number of single-byte `read` syscalls.

The documentation for [`serde_json::from_reader`](https://docs.rs/serde_json/latest/serde_json/fn.from_reader.html) states:
> When reading from a source against which short reads are not efficient, such as a [File](https://doc.rust-lang.org/std/fs/struct.File.html), you will want to apply your own buffering because serde_json will not buffer the input. See [std::io::BufReader](https://doc.rust-lang.org/std/io/struct.BufReader.html).

This PR adds the necessary `std::io::BufReader` to the places I saw it as necessary. To see the difference simply run `binary_to_types` with `strace` with an without this PR.

This PR also fixes up a trivial warning about unnecessary parenthesis, which I thought would be uncontroversial to include in the same PR, just to keep noise low. Let me know if I should open it as a separate PR instead (it's already as a separate commit in this PR fwiw).